### PR TITLE
Successfully creating a debian package. 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,8 @@
 ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = src
+
+dist_man_MANS = \
+	man/passphrase-identity.1
+
+EXTRA_DIST = LICENSE README.markdown

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-autoreconf --install --force -W all

--- a/debian/make-debianpkg.sh
+++ b/debian/make-debianpkg.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -o errexit
-
-git archive --format tar.gz --output /tmp/passphrase-identity_1.0.0.orig.tar.gz HEAD
-gbp buildpackage -uc -us --git-ignore-new --git-tarball-dir=/tmp
-lintian --profile debian --color=auto -iI ../passphrase-identity*.changes
-echo Debian pkg seems a-okay
-ls -d -- ../passphrase-identity*

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,12 +4,12 @@ passphrase_identity_CFLAGS = @PASSPHRASE_IDENTITY_CFLAGS@ @SODIUM_CFLAGS@
 passphrase_identity_LDFLAGS = @SODIUM_LIBS@
 
 passphrase_identity_SOURCES = \
-	buffer.c \
-	buffer_writer.c \
 	main.c \
-	memory.c \
-	openssh.c \
-	sha1.c \
-	openpgp.c \
-	profile.c \
-	readpassphrase.c
+	buffer.c buffer.h \
+	buffer_writer.c  buffer_writer.h \
+	memory.c memory.h \
+	openssh.c openssh.h \
+	sha1.c sha.h sha-private.h \
+	openpgp.c openpgp.h \
+	profile.c profile.h \
+	readpassphrase.c readpassphrase.h


### PR DESCRIPTION
Note: the project folder must be renamed to `passphrase-identity`.
Go with: 
```
make dist
mv passphrase-identity-1.0.0.tar.gz ../passphrase-identity_1.0.0.orig.tar.gz
dpkg-buildpackage [-us -uc]
```
debian package at https://mentors.debian.net/package/passphrase-identity.