### PR TITLE
fix #16 add missing autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+autoreconf --install --force


### PR DESCRIPTION
It seems that `autogen.sh` went missing after da7106b2758b2ea7973ecd9a39fb34ebe84abf1c.

So the instructions in the `README` no longer worked. This fixes that.